### PR TITLE
Feature/consumer gracefull shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
  "stream-cancel",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-futures",
  "trait-variant",
@@ -789,6 +790,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1100,7 +1107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2456,6 +2463,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "opentelemetry-nats",
  "serde",
  "serde_json",
+ "stream-cancel",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -2212,6 +2213,17 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stream-cancel"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9fbf9bd71e4cf18d68a8a0951c0e5b7255920c0cd992c4ff51cddd6ef514a3"
+dependencies = [
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ uuid = "1.8"
 kurrentdb = "1.0.0"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 stream-cancel = "0.8"
+tokio-util = { version = "0.7", features = ["rt"] }
 
 [package]
 name = "esrc"
@@ -68,6 +69,7 @@ uuid.workspace = true
 kurrentdb = { workspace = true, optional = true }
 tokio.workspace = true
 stream-cancel.workspace = true
+tokio-util.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,13 @@ serde = "1.0"
 serde_json = "1.0"
 syn = "2.0"
 thiserror = "2.0"
-tokio = { version ="1.41", features = ["rt"] }
+tokio = { version = "1.41", features = ["rt"] }
 tracing = "0.1"
 trait-variant = "0.1"
 uuid = "1.8"
 kurrentdb = "1.0.0"
-tracing-futures = { version = "0.2.5", features =["futures-03"] }
+tracing-futures = { version = "0.2.5", features = ["futures-03"] }
+stream-cancel = "0.8"
 
 [package]
 name = "esrc"
@@ -64,8 +65,9 @@ thiserror.workspace = true
 tracing.workspace = true
 trait-variant.workspace = true
 uuid.workspace = true
-kurrentdb = {workspace = true, optional = true}
+kurrentdb = { workspace = true, optional = true }
 tokio.workspace = true
+stream-cancel.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/examples/cafe/table.rs
+++ b/examples/cafe/table.rs
@@ -28,6 +28,10 @@ impl ActiveTables {
             .values()
             .any(|n| *n == table_number)
     }
+
+    pub async fn get_table_numbers(&self) -> HashMap<Uuid, u64> {
+        self.table_numbers.read().await.clone()
+    }
 }
 
 impl Project for ActiveTables {

--- a/src/event/event_model.rs
+++ b/src/event/event_model.rs
@@ -1,6 +1,7 @@
 use futures::Stream;
 use stream_cancel::Trigger;
 use tokio::sync::oneshot::Sender;
+use tokio_util::task::TaskTracker;
 
 use super::EventGroup;
 use crate::envelope;
@@ -42,8 +43,9 @@ pub trait Automation {
         &self,
         projector: P,
         feature_name: &str,
+        task_tracker: TaskTracker,
         exit_tx: Sender<Trigger>,
-    ) -> error::Result<()>
+    ) -> error::Result<TaskTracker>
     where
         P: Project + 'static;
 }
@@ -69,8 +71,9 @@ pub trait ViewAutomation: Automation {
         &self,
         projector: P,
         feature_name: &str,
+        task_tracker: TaskTracker,
         exit_tx: Sender<Trigger>,
-    ) -> error::Result<()>
+    ) -> error::Result<TaskTracker>
     where
         P: Project + 'static;
 }

--- a/src/event/event_model.rs
+++ b/src/event/event_model.rs
@@ -1,4 +1,6 @@
 use futures::Stream;
+use stream_cancel::Trigger;
+use tokio::sync::oneshot::Sender;
 
 use super::EventGroup;
 use crate::envelope;
@@ -29,6 +31,21 @@ pub trait Automation {
     async fn start_automation<P>(&self, projector: P, feature_name: &str) -> error::Result<()>
     where
         P: Project + 'static;
+
+    /// Subscribe to events and project them onto the given Project type, with a way to gracefully shutdown the process.
+    ///
+    /// Events published to any stream identified by the EventGroup type
+    /// parameter will be included.
+    ///
+    /// The exit_tx Sender can be used to send a Trigger that will stop the processing of new events.
+    async fn start_automation_with_graceful_shutdown<P>(
+        &self,
+        projector: P,
+        feature_name: &str,
+        exit_tx: Sender<Trigger>,
+    ) -> error::Result<()>
+    where
+        P: Project + 'static;
 }
 
 /// automation that projects events onto a read model
@@ -39,6 +56,21 @@ pub trait ViewAutomation: Automation {
     /// Events published to any stream identified by the EventGroup type
     /// parameter will be included.
     async fn start_view_automation<P>(&self, projector: P, feature_name: &str) -> error::Result<()>
+    where
+        P: Project + 'static;
+
+    /// Subscribe to events and project them onto the given Project type, with a way to gracefully shutdown the process.
+    ///
+    /// Events published to any stream identified by the EventGroup type
+    /// parameter will be included.
+    ///
+    /// The exit_tx Sender can be used to send a Trigger that will stop the processing of new events.
+    async fn start_view_automation_with_graceful_shutdown<P>(
+        &self,
+        projector: P,
+        feature_name: &str,
+        exit_tx: Sender<Trigger>,
+    ) -> error::Result<()>
     where
         P: Project + 'static;
 }


### PR DESCRIPTION
This pull request adds support for graceful shutdown of event automation processes by introducing new methods and dependencies. The main changes include adding the `stream-cancel` crate, updating the `Automation` and `ViewAutomation` traits with shutdown-capable methods, and implementing these methods for the `NatsStore` event backend.

**Graceful shutdown support for event automation:**

* Added the `stream-cancel` crate to dependencies and workspace to enable cancellation of event streams. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R31) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R70)
* Extended the `Automation` and `ViewAutomation` traits in `src/event/event_model.rs` with new methods (`start_automation_with_graceful_shutdown` and `start_view_automation_with_graceful_shutdown`) that accept a `Sender<Trigger>` for graceful shutdown. [[1]](diffhunk://#diff-890925b42514d8ad40ea8e8014eb8c4d6a49ac85b26414f5c1f8b3c4d2b598fcR34-R48) [[2]](diffhunk://#diff-890925b42514d8ad40ea8e8014eb8c4d6a49ac85b26414f5c1f8b3c4d2b598fcR61-R75)
* Implemented the new graceful shutdown methods for `NatsStore` in `src/nats/event.rs`, using `Valved` from `stream-cancel` to control event stream termination. [[1]](diffhunk://#diff-b8de01542b7d3b56c2eb7c1acf7d9721eafcb265b1c05b0eaf3a0b448fb99936R226-R255) [[2]](diffhunk://#diff-b8de01542b7d3b56c2eb7c1acf7d9721eafcb265b1c05b0eaf3a0b448fb99936R307-R333)
* Updated imports in relevant files to include `stream_cancel::Trigger`, `stream_cancel::Valved`, and `tokio::sync::oneshot::Sender` for shutdown support. [[1]](diffhunk://#diff-890925b42514d8ad40ea8e8014eb8c4d6a49ac85b26414f5c1f8b3c4d2b598fcR2-R3) [[2]](diffhunk://#diff-b8de01542b7d3b56c2eb7c1acf7d9721eafcb265b1c05b0eaf3a0b448fb99936R147-R149)